### PR TITLE
Complete search for all tree elements.

### DIFF
--- a/src/main/java/gov/cancer/framework/ElementHelper.java
+++ b/src/main/java/gov/cancer/framework/ElementHelper.java
@@ -37,7 +37,7 @@ public class ElementHelper {
 
   /**
    * This method returns the list of elements on the page defined by a certain
-   * selector.
+   * selector. If no elements are found, an empty list is returned.
    *
    * @param parent
    *          - page WebDriver or WebElement.
@@ -47,11 +47,7 @@ public class ElementHelper {
   public static List<WebElement> findElements(SearchContext parent, String selector) {
 
     List<WebElement> findList = parent.findElements(By.cssSelector(selector));
-    if (findList.size() > 0) {
-      return findList;
-    } else {
-      return null;
-    }
+    return findList;
   }
 
   /**

--- a/src/main/java/gov/cancer/pageobject/leftnavigation/NavItem.java
+++ b/src/main/java/gov/cancer/pageobject/leftnavigation/NavItem.java
@@ -1,6 +1,7 @@
 
 package gov.cancer.pageobject.leftnavigation;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.openqa.selenium.WebElement;
@@ -8,21 +9,22 @@ import gov.cancer.framework.ElementHelper;
 
 public class NavItem {
 
-  private List<NavItem> children;
+  private List<NavItem> children = new ArrayList<NavItem>();
   private WebElement element;
+  private WebElement textElement;
 
   public NavItem(WebElement element) {
 
     this.element = element;
+    this.textElement = ElementHelper.findElement(element, ":scope > div");
 
-    List<WebElement> subElements = ElementHelper.findElements(element, "ul > li");
+    List<WebElement> subElements = ElementHelper.findElements(element, ":scope > ul > li");
 
     for (WebElement we : subElements) {
 
       NavItem child = new NavItem(we);
 
       children.add(child);
-
     }
 
   }

--- a/src/test/java/gov/cancer/tests/crosscutting/LeftNav_Test.java
+++ b/src/test/java/gov/cancer/tests/crosscutting/LeftNav_Test.java
@@ -8,26 +8,23 @@ public class LeftNav_Test extends TestObjectBase {
 
 
   public void fake_test() {
-    
+
     String path ="about-cancer/coping/feelings";
-    
+
     TestRunner.run(PageWithSectionNav.class, path, (PageWithSectionNav page) -> {
 
-  
-     
-      
     });
     }
-    
-  
-  
+
+
+
   public static void main(String[] args) {
     LeftNav_Test test = new LeftNav_Test();
     test.fake_test();
   }
-  
-  
-  
-  
+
+
+
+
 
 }


### PR DESCRIPTION
- Use ':scope` pseudo element to restrict search to immediate children.
- Initialize list of children.
- Adjust ElementHelper::findElements() to return an empty list when nothing is found.